### PR TITLE
Nginx導入時の設定変更

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -11,7 +11,7 @@ working_directory app_path
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
 #ポート番号を指定
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 #エラーのログを記録するファイルを指定
 stderr_path "#{app_path}/log/unicorn.stderr.log"


### PR DESCRIPTION
what
uinicornの接続に３０００という番号がいらなくなった
why
Nginxを使う際に使うため
